### PR TITLE
Fix Tests

### DIFF
--- a/test/NotEqual.js
+++ b/test/NotEqual.js
@@ -24,7 +24,7 @@ describe("NotEqual Test ", function (){
         assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
         assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput)));
         
-        witness = await circuit.calculateWitness({"a":[1,2]},true);
+        witness = await circuit.calculateWitness({"a":[1,7]},true);
         let expectedOutput2 = 1;
         assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
         assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput2)));

--- a/test/Pow.js
+++ b/test/Pow.js
@@ -29,5 +29,9 @@ describe("Power Modulo Test ", function (){
         assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
         assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput2)));
     
+        witness = await circuit.calculateWitness({"a":[4,0]},true);
+        let expectedOutput3  = 1;
+        assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
+        assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput3)));
     })
 })


### PR DESCRIPTION
- As NotEqual is based on negation it is better that number should differ more than by 1.
- For Pow circuit we need to cover edge case: exp == 0.