### PR TITLE
adding test cases to Equality to cover two other input scenarios

### DIFF
--- a/test/Equality.js
+++ b/test/Equality.js
@@ -29,6 +29,14 @@ describe("Equality Test ", function (){
         assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
         assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput2)));
 
-    
+        witness = await circuit.calculateWitness({"a":[1,1,0]},true);
+        let expectedOutput3 = 0;
+        assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
+        assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput3)));
+
+        witness = await circuit.calculateWitness({"a":[2,1,1]},true);
+        let expectedOutput4 = 0;
+        assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
+        assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput4)));
     })
 })


### PR DESCRIPTION
A naive solution for the Equality challenge which only checks equality between the first 2 elements would pass with the existing test suite.

This patch adds 2 additional test cases that would prevent such a naive solution from passing the Equality test suite.