### PR TITLE
Addressed issues #16, #7 and #5

### DIFF
--- a/Compile/script.sh
+++ b/Compile/script.sh
@@ -49,8 +49,11 @@ snarkjs groth16 prove Mul_0001.zkey witness.wtns proof.json public.json
 # Verify the proof
 snarkjs groth16 verify verification_key.json public.json proof.json
 
+# Create `contracts` directory
+mkdir contracts
+
 # Generate a Solidity verifier that allows verifying proofs on Ethereum blockchain
-snarkjs zkey export solidityverifier Mul_0001.zkey ../contracts/verifier.sol
+snarkjs zkey export solidityverifier Mul_0001.zkey ./contracts/verifier.sol
 
 # Generate and print parameters of call
 snarkjs generatecall | tee parameters.txt

--- a/test/MultiplyNoOut.js
+++ b/test/MultiplyNoOut.js
@@ -1,27 +1,31 @@
-const chai = require('chai');
-const { wasm } = require('circom_tester');
+const chai = require("chai");
+const { wasm } = require("circom_tester");
 const path = require("path");
 const F1Field = require("ffjavascript").F1Field;
 const Scalar = require("ffjavascript").Scalar;
-exports.p = Scalar.fromString("21888242871839275222246405745257275088548364400416034343698204186575808495617");
+exports.p = Scalar.fromString(
+  "21888242871839275222246405745257275088548364400416034343698204186575808495617",
+);
 const Fr = new F1Field(exports.p);
 var chaiAsPromised = require("chai-as-promised");
 const wasm_tester = require("circom_tester").wasm;
 
-
 chai.use(chaiAsPromised);
 const expect = chai.expect;
 
-describe("Add Test ", function (){
-    this.timeout(100000);
+describe("Add Test ", function () {
+  this.timeout(100000);
 
-    it("Should validate a multiplication", async()=>{
-        const circuit = await wasm_tester(path.join(__dirname,"../MultiplyNoOutput/","MultiplyNoOutput.circom"));
-        await circuit.loadConstraints();
+  it("Should validate a multiplication", async () => {
+    const circuit = await wasm_tester(
+      path.join(__dirname, "../MultiplyNoOut/", "MultiplyNoOut.circom"),
+    );
+    await circuit.loadConstraints();
 
-        let witness = await circuit.calculateWitness({"in":[4,5,20]},true);
-        expect(witness.length).to.equal(4);
+    let witness = await circuit.calculateWitness({ in: [4, 5, 20] }, true);
+    expect(witness.length).to.equal(4);
 
-        await expect(circuit.calculateWitness({"in": [4,5,21]}, true)).to.be.eventually.rejected;
-    });
+    await expect(circuit.calculateWitness({ in: [4, 5, 21] }, true)).to.be
+      .eventually.rejected;
+  });
 });


### PR DESCRIPTION
issue #16:
       `MultiplyNoOut.js` test used an incorrect circuit filename.
        solution: renamed to the one.

issue #7:
        Error with `script.sh` while generating `verifier.sol` contract inside `..\contracts` directory.
        solution: added a command in the script to make `contracts` dir, then modified the command that generates the 
                        `verifier.sol`.

issue #5:
         PR for this issue has been merged.