### PR TITLE
Fix hashes in Salt-challenge test

### DIFF
--- a/test/Salt.js
+++ b/test/Salt.js
@@ -18,7 +18,7 @@ describe(" mimcSponge  ", function (){
         await circuit.loadConstraints();
         let witness ; 
         
-        const expectedOutput = 9298463176047380197626371459244539548819181814394649924288766436865924479390n;
+        const expectedOutput = 17588055722251891539725204770637639669261029749544372363945149066696774180511n;
         
         witness = await circuit.calculateWitness({"a":"4","b":"4","salt":"2"},true);
 
@@ -27,7 +27,7 @@ describe(" mimcSponge  ", function (){
 
         witness = await circuit.calculateWitness({"a":"45","b":"1001","salt":"0099"},true);
         
-        const expectedOutput2 = 17165551905088735098668729485755579194569447435279436338955576584338338632036n;
+        const expectedOutput2 = 21789734462778371607222800966534358127947886088940268109596186508023018029595n;
         assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
         assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput2)));
     


### PR DESCRIPTION
This pull request includes updates to the expected output values in the `mimcSponge` tests within the `test/Salt.js` file. These changes ensure that the test cases reflect the correct expected results.

Changes to test cases:

* [`test/Salt.js`](diffhunk://#diff-217d8c6de480972964c26f8551d83d0f84db19542cbbb8619c3547040fc62c49L21-R21): Updated the `expectedOutput` value in the `mimcSponge` test to `17588055722251891539725204770637639669261029749544372363945149066696774180511n`.
* [`test/Salt.js`](diffhunk://#diff-217d8c6de480972964c26f8551d83d0f84db19542cbbb8619c3547040fc62c49L30-R30): Updated the `expectedOutput2` value in the `mimcSponge` test to `21789734462778371607222800966534358127947886088940268109596186508023018029595n`.

These new hash values have been produced with zkREPL and the following solution to the puzzle:

```
pragma circom 2.1.4;

include "../node_modules/circomlib/circuits/mimcsponge.circom";

// In this exercise, we will learn an important concept related to hashing . There are 2 values a and b. You want to 
// perform computation on these and verify it , but secretly without discovering the values. 
// One way is to hash the 2 values and then store the hash as a reference. 
// There is one problem in this concept, attacker can brute force the 2 variables by comparing the public hash with the resulting hash.
// To overcome this , we use a secret value in the input privately. We hash it with a and b. 

// This way brute force becomes illogical as the cost will increase multifolds for the attacker.


// Input 3 values, a, b and salt. 
// Hash all 3 using mimcsponge as a hashing mechanism. 
// Output the res using 'out'.

template Salt() {
    signal input a;
    signal input b;
    signal input salt;
    signal output out;

    component mimcSponge = MiMCSponge(3, 220, 1);

    mimcSponge.ins[0] <== a;
    mimcSponge.ins[1] <== b;
    mimcSponge.ins[2] <== salt;
    mimcSponge.k <== 0;

    out <== mimcSponge.outs[0];
}

component main  = Salt();
// By default all inputs are private in circom. We will not define any input as public 
// because we want them to be a secret , at least in this case. 

// There will be cases where some values will be declared explicitly public .

// Input corresponding to the second test case in test/Salt.js
/* INPUT = {
    "a": "45",
    "b": "1001",
    "salt": "0099"
} */
```

There is, of course, a chance that my solution is simply wrong, but in case it's correct, the hash values in the test should be changed.