### PR TITLE
update: Adding inner box checks to Sudoku

### DIFF
--- a/test/Sudoku.js
+++ b/test/Sudoku.js
@@ -58,5 +58,41 @@ describe("Sudoku Tester ", function () {
     const expectedOutput3 = 0;
     assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
     assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput3)));
+
+    // Valid solution test with box constraint satisfied
+    witness = await circuit.calculateWitness({
+    question:  ["1","0","0","0",
+                "0","4","0","0",
+                "0","0","4","0",
+                "0","0","0","1"
+              ],
+    solution: ["1","2","3","4",
+                "3","4","1","2",
+                "2","1","4","3",
+                "4","3","2","1"
+              ]
+    }, true);
+
+    const expectedOutput4 = 1;
+    assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
+    assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput4)));
+
+    // Invalid solution test where box constraint is violated
+    witness = await circuit.calculateWitness({
+      question: ["1","0","0","0",
+                 "0","1","0","0",
+                 "0","0","1","0",
+                 "0","0","0","1"
+                ],
+      solution: ["1","2","3","4",
+                 "2","1","4","3",
+                 "3","4","1","2",
+                 "4","3","2","1"
+                ]
+    }, true);
+
+    const expectedOutput5 = 0;
+    assert(Fr.eq(Fr.e(witness[0]), Fr.e(1)));
+    assert(Fr.eq(Fr.e(witness[1]), Fr.e(expectedOutput5)));
   });
 });


### PR DESCRIPTION
Current Sudoku test cases are not explicitly checking the inner box checks of the solution. 

### Valid Inner Boxes

```
Question:          Solution:
[1, 0, 0, 0]      [1, 4, 3, 2]
[0, 2, 0, 0]      [3, 2, 1, 4]
[0, 0, 3, 0]      [4, 1, 3, 2]
[0, 0, 0, 4]      [2, 3, 4, 1]
```

```
Box 0 (top-left):     Box 1 (top-right):
[1, 4]                [3, 2]
[3, 2]                [1, 4]
Values: {1,2,3,4} ✓   Values: {1,2,3,4} ✓

Box 2 (bottom-left):  Box 3 (bottom-right):
[4, 1]                [3, 2]
[2, 3]                [4, 1]
Values: {1,2,3,4} ✓   Values: {1,2,3,4} ✓
```

### Invalid Inner Boxes

```
Question:          Solution:
[1, 0, 0, 0]      [1, 2, 3, 4]
[0, 1, 0, 0]      [2, 1, 4, 3]
[0, 0, 1, 0]      [3, 4, 1, 2]
[0, 0, 0, 1]      [4, 3, 2, 1]
```

```
Box 0 (top-left):     Box 1 (top-right):
[1, 2]                [3, 4]
[2, 1]                [4, 3]
Values: {1,2,2,1} - Invalid ; Values: {3,4,4,3}  - Invalid

Box 2 (bottom-left):  Box 3 (bottom-right):
[3, 4]                [1, 2]
[4, 3]                [2, 1]
Values: {3,4,4,3} - Invalid   Values: {1,2,2,1} - Invalid
```

Because of no such test case to check inner boxes the invalid sudoku will still pass the test. 

**This makes sudoko a bit more hard puzzle, a good challenge for solvers**